### PR TITLE
Change FetchMessages to use inclusive offset

### DIFF
--- a/memorydatabase.go
+++ b/memorydatabase.go
@@ -73,10 +73,10 @@ func (m *MemoryDatabase) FetchMessages(topic string, startOffset, endOffset int6
 	if startOffset >= endOffset {
 		return nil, fmt.Errorf("start offset %d greater than or equal to end offset %d", startOffset, endOffset)
 	}
-	if startOffset < -1 {
-		return nil, fmt.Errorf("start offset %d less than -1", startOffset)
+	if startOffset < 0 {
+		return nil, fmt.Errorf("start offset %d less than 0", startOffset)
 	}
-	return messages[startOffset+1 : endOffset], nil
+	return messages[startOffset:endOffset], nil
 }
 
 // MaxOffsets implements Database

--- a/naffka.go
+++ b/naffka.go
@@ -138,6 +138,7 @@ func (n *Naffka) Partitions(topic string) ([]int32, error) {
 }
 
 // ConsumePartition implements sarama.Consumer
+// Note: offset is *inclusive*, i.e. it will include the message with that offset.
 func (n *Naffka) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
 	if partition != 0 {
 		return nil, fmt.Errorf("Unknown partition ID %d", partition)
@@ -254,10 +255,12 @@ func (c *partitionConsumer) catchup(fromOffset int64) {
 }
 
 type topic struct {
-	db         Database
-	topicName  string
-	mutex      sync.Mutex
-	consumers  []*partitionConsumer
+	db        Database
+	topicName string
+	mutex     sync.Mutex
+	consumers []*partitionConsumer
+	// nextOffset is the offset that will be assigned to the next message in
+	// this topic, i.e. one greater than the last message offset.
 	nextOffset int64
 }
 

--- a/postgresqldatabase.go
+++ b/postgresqldatabase.go
@@ -42,7 +42,7 @@ const insertMessageSQL = "" +
 
 const selectMessagesSQL = "" +
 	"SELECT message_offset, message_key, message_value, message_timestamp_ns" +
-	" FROM naffka_messages WHERE topic_nid = $1 AND $2 < message_offset AND message_offset < $3" +
+	" FROM naffka_messages WHERE topic_nid = $1 AND $2 <= message_offset AND message_offset < $3" +
 	" ORDER BY message_offset ASC"
 
 const selectMaxOffsetSQL = "" +


### PR DESCRIPTION
ConsumePartition takes an `offset` param from which to stream messages
from, which is *inclusive*, i.e. will include the message with that
offset. FetchMessages also takes an offset, but returned messages excluding the
initial offset.

This lead to confusion in the code about whehter fromOffset is
inclusive or exclusive at any given point.

This changes it so that the two functions are consistent and are
inclusive.