### PR TITLE
 Fix bug when the consumer channel fills up

### DIFF
--- a/memorydatabase.go
+++ b/memorydatabase.go
@@ -8,7 +8,8 @@ import (
 // A MemoryDatabase stores the message history as arrays in memory.
 // It can be used to run unit tests.
 // If the process is stopped then any messages that haven't been
-// processed by a consumer are lost forever.
+// processed by a consumer are lost forever and all offsets become
+// invalid.
 type MemoryDatabase struct {
 	topicsMutex sync.Mutex
 	topics      map[string]*memoryDatabaseTopic
@@ -58,10 +59,7 @@ func (m *MemoryDatabase) getTopic(topicName string) *memoryDatabaseTopic {
 
 // StoreMessages implements Database
 func (m *MemoryDatabase) StoreMessages(topic string, messages []Message) error {
-	if err := m.getTopic(topic).addMessages(messages); err != nil {
-		return err
-	}
-	return nil
+	return m.getTopic(topic).addMessages(messages)
 }
 
 // FetchMessages implements Database

--- a/naffka.go
+++ b/naffka.go
@@ -221,9 +221,11 @@ func (c *partitionConsumer) catchup(fromOffset int64) {
 
 	c.catchingUp = true
 
+	// Due to the checks above there can only be one of these goroutines
+	// running at a time
 	go func() {
 		for {
-			// Check if we're up to date yet.
+			// Check if we're up to date yet. If we are we exit catchup mode.
 			c.topic.mutex.Lock()
 			nextOffset := c.topic.nextOffset
 			if fromOffset == nextOffset {

--- a/naffka.go
+++ b/naffka.go
@@ -13,6 +13,7 @@ import (
 // single go process. It implements both the sarama.SyncProducer and the
 // sarama.Consumer interfaces. This means it can act as a drop in replacement
 // for kafka for testing or single instance deployment.
+// Does not support multiple partitions.
 type Naffka struct {
 	db          Database
 	topicsMutex sync.Mutex
@@ -168,13 +169,16 @@ func (n *Naffka) Close() error {
 
 const channelSize = 1024
 
+// partitionConsumer ensures that all messages written to a particular
+// topic, from an offset, get sent in order to a channel.
+// Implements sarama.PartitionConsumer
 type partitionConsumer struct {
 	topic    *topic
 	messages chan *sarama.ConsumerMessage
-	// Whether the consumer is ready for new messages or whether it
-	// is catching up on historic messages.
+	// Whether the consumer is in "catchup" mode or not.
+	// See "catchup" function for details.
 	// Reads and writes to this field are proctected by the topic mutex.
-	ready bool
+	catchingUp bool
 }
 
 // AsyncClose implements sarama.PartitionConsumer
@@ -203,55 +207,83 @@ func (c *partitionConsumer) HighWaterMarkOffset() int64 {
 	return c.topic.highwaterMark()
 }
 
-// block writes the message to the consumer blocking until the consumer is ready
-// to add the message to the channel. Once the message is successfully added to
-// the channel it will catch up by pulling historic messsages from the database.
-func (c *partitionConsumer) block(cmsg *sarama.ConsumerMessage) {
-	c.messages <- cmsg
-	c.catchup(cmsg.Offset)
+// catchup makes the consumer go into "catchup" mode, where messages are read
+// from the database instead of directly from producers.
+// Once the consumer is up to date, i.e. no new messages in the database, then
+// the consumer will go back into normal mode where new messages are written
+// directly to the channel.
+// Must be called with the c.topic.mutex lock
+func (c *partitionConsumer) catchup(fromOffset int64) {
+	// If we're already in catchup mode or up to date, noop
+	if c.catchingUp || fromOffset == c.topic.nextOffset {
+		return
+	}
+
+	c.catchingUp = true
+
+	go func() {
+		for {
+			// Check if we're up to date yet.
+			c.topic.mutex.Lock()
+			nextOffset := c.topic.nextOffset
+			if fromOffset == nextOffset {
+				c.catchingUp = false
+				c.topic.mutex.Unlock()
+				return
+			}
+			c.topic.mutex.Unlock()
+
+			// Limit the number of messages we request from the database to be the
+			// capacity of the channel.
+			if nextOffset > fromOffset+int64(cap(c.messages)) {
+				nextOffset = fromOffset + int64(cap(c.messages))
+			}
+			// Fetch the messages from the database.
+			msgs, err := c.topic.db.FetchMessages(c.topic.topicName, fromOffset, nextOffset)
+			if err != nil {
+				// TODO: Add option to write consumer errors to an errors channel
+				// as an alternative to logging the errors.
+				log.Print("Error reading messages: ", err)
+				// Wait before retrying.
+				// TODO: Maybe use an exponentional backoff scheme here.
+				// TODO: This timeout should take account of all the other goroutines
+				// that might be doing the same thing. (If there are a 10000 consumers
+				// then we don't want to end up retrying every millisecond)
+				time.Sleep(10 * time.Second)
+				continue
+			}
+			if len(msgs) == 0 {
+				// This should only happen if the database is corrupted and has lost the
+				// messages between the requested offsets.
+				log.Fatalf("Corrupt database returned no messages between %d and %d", fromOffset, nextOffset)
+			}
+
+			// Pass the messages into the consumer channel.
+			// Blocking each write until the channel has enough space for the message.
+			for i := range msgs {
+				c.messages <- msgs[i].consumerMessage(c.topic.topicName)
+			}
+			// Update our the offset for the next loop iteration.
+			fromOffset = msgs[len(msgs)-1].Offset + 1
+		}
+	}()
 }
 
-// catchup reads historic messages from the database until the consumer has caught
-// up on all the historic messages.
-func (c *partitionConsumer) catchup(fromOffset int64) {
-	for {
-		// First check if we have caught up.
-		caughtUp, nextOffset := c.topic.hasCaughtUp(c, fromOffset)
-		if caughtUp {
-			return
+// notifyNewMessage tells the consumer about a new message
+// Must be called with the c.topic.mutex lock
+func (c *partitionConsumer) notifyNewMessage(cmsg *sarama.ConsumerMessage) {
+	// If we're in "catchup" mode then the catchup routine will send the
+	// message later, since cmsg has already been written to the database
+	if !c.catchingUp {
+		// Otherwise, lets try writing the message directly to the channel
+		select {
+		case c.messages <- cmsg:
+		default:
+			// The messages channel has filled up, so lets go into catchup
+			// mode. Once the channel starts being read from again messages
+			// will be read from the database
+			c.catchup(cmsg.Offset)
 		}
-		// Limit the number of messages we request from the database to be the
-		// capacity of the channel.
-		if nextOffset > fromOffset+int64(cap(c.messages)) {
-			nextOffset = fromOffset + int64(cap(c.messages))
-		}
-		// Fetch the messages from the database.
-		msgs, err := c.topic.db.FetchMessages(c.topic.topicName, fromOffset, nextOffset)
-		if err != nil {
-			// TODO: Add option to write consumer errors to an errors channel
-			// as an alternative to logging the errors.
-			log.Print("Error reading messages: ", err)
-			// Wait before retrying.
-			// TODO: Maybe use an exponentional backoff scheme here.
-			// TODO: This timeout should take account of all the other goroutines
-			// that might be doing the same thing. (If there are a 10000 consumers
-			// then we don't want to end up retrying every millisecond)
-			time.Sleep(10 * time.Second)
-			continue
-		}
-		if len(msgs) == 0 {
-			// This should only happen if the database is corrupted and has lost the
-			// messages between the requested offsets.
-			log.Fatalf("Corrupt database returned no messages between %d and %d", fromOffset, nextOffset)
-		}
-
-		// Pass the messages into the consumer channel.
-		// Blocking each write until the channel has enough space for the message.
-		for i := range msgs {
-			c.messages <- msgs[i].consumerMessage(c.topic.topicName)
-		}
-		// Update our the offset for the next loop iteration.
-		fromOffset = msgs[len(msgs)-1].Offset + 1
 	}
 }
 
@@ -265,6 +297,7 @@ type topic struct {
 	nextOffset int64
 }
 
+// send writes messages to a topic.
 func (t *topic) send(now time.Time, pmsgs []*sarama.ProducerMessage) error {
 	var err error
 	// Encode the message keys and values.
@@ -302,21 +335,10 @@ func (t *topic) send(now time.Time, pmsgs []*sarama.ProducerMessage) error {
 	t.nextOffset = offset
 
 	// Now notify the consumers about the messages.
-	for i := range msgs {
-		cmsg := msgs[i].consumerMessage(t.topicName)
+	for _, msg := range msgs {
+		cmsg := msg.consumerMessage(t.topicName)
 		for _, c := range t.consumers {
-			if c.ready {
-				select {
-				case c.messages <- cmsg:
-				default:
-					// The consumer wasn't ready to receive a message because
-					// the channel buffer was full.
-					// Fork a goroutine to send the message so that we don't
-					// block sending messages to the other consumers.
-					c.ready = false
-					go c.block(cmsg)
-				}
-			}
+			c.notifyNewMessage(cmsg)
 		}
 	}
 
@@ -338,23 +360,13 @@ func (t *topic) consume(offset int64) *partitionConsumer {
 	}
 	c.messages = make(chan *sarama.ConsumerMessage, channelSize)
 	t.consumers = append(t.consumers, c)
-	// Start catching up on historic messages in the background.
-	go c.catchup(offset)
-	return c
-}
 
-func (t *topic) hasCaughtUp(c *partitionConsumer, offset int64) (bool, int64) {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-	// Check if we have caught up while holding a lock on the topic so there
-	// isn't a way for our check to race with a new message being sent on the topic.
-	if offset == t.nextOffset {
-		// We've caught up, the consumer can now receive messages as they are
-		// sent rather than fetching them from the database.
-		c.ready = true
-		return true, t.nextOffset
+	// If we're not streaming from the latest offset we need to go into
+	// "catchup" mode
+	if offset != t.nextOffset {
+		c.catchup(offset)
 	}
-	return false, t.nextOffset
+	return c
 }
 
 func (t *topic) highwaterMark() int64 {

--- a/naffka_test.go
+++ b/naffka_test.go
@@ -180,6 +180,9 @@ func TestChannelSaturation(t *testing.T) {
 	}
 
 	channelSize := cap(c.Messages())
+
+	// We want to send enough messages to fill up the channel, so lets double
+	// the size of the channel. And add three in case its a zero sized channel
 	numberMessagesToSend := 2*channelSize + 3
 
 	var sentMessages []string

--- a/naffka_test.go
+++ b/naffka_test.go
@@ -1,6 +1,7 @@
 package naffka
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -158,5 +159,65 @@ func TestCatchup(t *testing.T) {
 
 	if string(result2.Value) != value2 {
 		t.Fatalf("wrong value: wanted %q got %q", value2, string(result2.Value))
+	}
+}
+
+func TestChannelSaturation(t *testing.T) {
+	// The channel returned by c.Messages() has a fixed capacity
+
+	naffka, err := New(&MemoryDatabase{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	producer := sarama.SyncProducer(naffka)
+	consumer := sarama.Consumer(naffka)
+	const topic = "testTopic"
+	const baseValue = "testValue: "
+
+	c, err := consumer.ConsumePartition(topic, 0, sarama.OffsetOldest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	channelSize := cap(c.Messages())
+	numberMessagesToSend := 2*channelSize + 3
+
+	var sentMessages []string
+
+	for i := 0; i < numberMessagesToSend; i++ {
+		value := baseValue + strconv.Itoa(i)
+
+		message := sarama.ProducerMessage{
+			Topic: topic,
+			Value: sarama.StringEncoder(value),
+		}
+
+		sentMessages = append(sentMessages, value)
+
+		if _, _, err = producer.SendMessage(&message); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var result *sarama.ConsumerMessage
+
+	j := 0
+	for ; j < numberMessagesToSend; j++ {
+		select {
+		case result = <-c.Messages():
+		case _ = <-time.NewTimer(10 * time.Second).C:
+			t.Fatalf("failed to receive message %d out of %d", j+1, numberMessagesToSend)
+		}
+
+		expectedValue := sentMessages[j]
+		if string(result.Value) != expectedValue {
+			t.Fatalf("wrong value: wanted %q got %q", expectedValue, string(result.Value))
+		}
+	}
+
+	select {
+	case result = <-c.Messages():
+		t.Fatalf("expected to only receive %d messages", numberMessagesToSend)
+	default:
 	}
 }


### PR DESCRIPTION
Once the channel fills up the consumer goes into "catchup" mode. This is
where instead of new messages being written directly to the channel,
messages are pulled from the database asynchronously (when the channel
has free space again).

This PR refactors the code to (hopefully) make this more explicit, while
also fixing a bug where we ended up sending messages multiple times.